### PR TITLE
Add `requiresHttpClient` switch to the `AddProvider` method

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter()]
-    [string]$VersionPrefix = "1.1.0",
+    [string]$VersionPrefix = "1.1.1",
 
     [Parameter()]
     [int]$BuildNumber = 0,

--- a/src/TakNotify.AspNetCore/NoHttpClientFactoryException.cs
+++ b/src/TakNotify.AspNetCore/NoHttpClientFactoryException.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Frandi Dwi 2020. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Net.Http;
+
+namespace TakNotify
+{
+    /// <summary>
+    /// Exception to throw when <see cref="IHttpClientFactory"/> was not found in the service collection,
+    /// <br/>but a provider that requires the type is trying to be added to the <see cref="INotification"/> object.
+    /// <br/>Fixing this issue could be as simple as setting the 'requiresHttpClient = false' in <see cref="NotificationBuilder.AddProvider"/>
+    /// </summary>
+    public class NoHttpClientFactoryException : Exception
+    {
+        private const string messageFormat = "Unable to resolve 'System.Net.Http.IHttpClientFactory' when trying to add '{0}' provider";
+
+        /// <summary>
+        /// Create the instance of <see cref="NoHttpClientFactoryException"/>
+        /// </summary>
+        /// <param name="providerName">Name of the provider that requires <see cref="IHttpClientFactory"/></param>
+        public NoHttpClientFactoryException(string providerName) 
+            : base(string.Format(messageFormat, providerName))
+        {
+            ProviderName = providerName;
+        }
+
+        /// <summary>
+        /// Create the instance of <see cref="NoHttpClientFactoryException"/>
+        /// </summary>
+        /// <param name="providerName">Name of the provider that requires <see cref="IHttpClientFactory"/></param>
+        /// <param name="innerException">The inner exception</param>
+        public NoHttpClientFactoryException(string providerName, Exception innerException) 
+            : base(string.Format(messageFormat, providerName), innerException)
+        {
+            ProviderName = providerName;
+        }
+
+        /// <summary>
+        /// Name of the provider that requires <see cref="IHttpClientFactory"/>
+        /// </summary>
+        public string ProviderName { get; }
+    }
+}

--- a/src/TakNotify.AspNetCore/TakNotify.AspNetCore.csproj
+++ b/src/TakNotify.AspNetCore/TakNotify.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Summary>The extension for TakNotify library to work with ASP.NET Core apps</Summary>
     <Description>The extension for TakNotify library to work with ASP.NET Core apps</Description>
-    <Authors>Frandi Dwi</Authors>
+    <Authors>frandi-dwi</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/TakNotify/TakNotify.AspNetCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/TakNotify.AspNetCore/TakNotify.AspNetCore.csproj
+++ b/src/TakNotify.AspNetCore/TakNotify.AspNetCore.csproj
@@ -16,11 +16,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
     <PackageReference Include="TakNotify" Version="1.1.0" />
   </ItemGroup>

--- a/test/TakNotify.AspNetCore.Test/DependencyInjectionTest.cs
+++ b/test/TakNotify.AspNetCore.Test/DependencyInjectionTest.cs
@@ -46,5 +46,48 @@ namespace TakNotify.AspNetCore.Test
 
             _notification.Verify(n => n.AddProvider(It.IsAny<DummyProvider>()), Times.Once);
         }
+
+        [Fact]
+        public void AddProvider_WithHttp_Success()
+        {
+            _notification.Setup(n => n.AddProvider(It.IsAny<NotificationProvider>()))
+                .Returns(_notification.Object);
+
+            _services.AddSingleton(_notification.Object);
+
+            var builder = new NotificationBuilder(_services);
+            builder.AddProvider<DummyHttpProvider, NotificationProviderOptions>(options => { }, true);
+
+            _notification.Verify(n => n.AddProvider(It.IsAny<DummyHttpProvider>()), Times.Once);
+        }
+
+        [Fact]
+        public void AddProviders_Success()
+        {
+            _notification.Setup(n => n.AddProvider(It.IsAny<NotificationProvider>()))
+                .Returns(_notification.Object);
+
+            _services.AddSingleton(_notification.Object);
+
+            var builder = new NotificationBuilder(_services);
+            builder.AddProvider<DummyProvider, NotificationProviderOptions>(options => { });
+            builder.AddProvider<DummyHttpProvider, NotificationProviderOptions>(options => { }, true);
+
+            _notification.Verify(n => n.AddProvider(It.IsAny<NotificationProvider>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void AddProvider_WithHttp_NoHttpClientFactory()
+        {
+            _notification.Setup(n => n.AddProvider(It.IsAny<NotificationProvider>()))
+                .Returns(_notification.Object);
+
+            _services.AddSingleton(_notification.Object);
+
+            var builder = new NotificationBuilder(_services);
+            var exception = Record.Exception(() => builder.AddProvider<DummyHttpProvider, NotificationProviderOptions>(options => { }));
+
+            Assert.IsType<NoHttpClientFactoryException>(exception);
+        }
     }
 }

--- a/test/TakNotify.AspNetCore.Test/DummyHttpProvider.cs
+++ b/test/TakNotify.AspNetCore.Test/DummyHttpProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Frandi Dwi 2020. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace TakNotify.AspNetCore.Test
+{
+    public class DummyHttpProvider : NotificationProvider {
+        public const string DefaultName = "DummyHttp";
+        
+        public DummyHttpProvider(IOptions<NotificationProviderOptions> options, IHttpClientFactory httpClientFactory)
+            : base(options.Value, new NullLoggerFactory())
+        {
+            
+        }
+
+        public override string Name => DefaultName;
+
+        public override Task<NotificationResult> Send (MessageParameterCollection messageParameters) {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `requiresHttpClient` switch to the `AddProvider` method
- Add unit tests to test provider with `IHttpClientFactory`
- Increase version to `1.1.1`